### PR TITLE
Fix minor UI issues in /plan page around timetable

### DIFF
--- a/src/app/plan/sidebarView.tsx
+++ b/src/app/plan/sidebarView.tsx
@@ -618,7 +618,7 @@ const handleButtonClick = (action) => {
         </div>
       </section>
 
-      <section className="w-full md:w-3/4 pr-6 pb-6">
+      <section className="w-full md:w-3/4">
         <TimetableView
           courseList={selectedCourseList}
           unitColors={unitColors}

--- a/src/app/plan/timetableView.tsx
+++ b/src/app/plan/timetableView.tsx
@@ -92,7 +92,7 @@ const Timetable: React.FC<TimetableProps> = ({ courses, unitColors }) => {
   return (
     <div className="w-full overflow-x-auto">
       {/* Header row with day names */}
-      <div className="mt-6 grid grid-cols-[1fr_2fr_2fr_2fr_2fr_2fr] gap-2 text-white bg-blue-1400 p-4">
+      <div className="grid grid-cols-[1fr_2fr_2fr_2fr_2fr_2fr] gap-2 text-white bg-blue-1400 p-4">
         <div></div>
         {daysOfWeek.map((day) => (
           <div key={day} className="text-center font-bold">
@@ -102,7 +102,7 @@ const Timetable: React.FC<TimetableProps> = ({ courses, unitColors }) => {
       </div>
 
       {/* Timetable grid */}
-      <div className="grid grid-cols-[1fr_2fr_2fr_2fr_2fr_2fr] gap-2 relative bg-white">
+      <div className="grid grid-cols-[1fr_2fr_2fr_2fr_2fr_2fr] relative bg-white">
         {/* Time Column */}
         <div className="flex flex-col text-white relative">
           {timeSlots.map((time) => (


### PR DESCRIPTION
Fixed minor UI issues by removing top margin for timetable, removing right padding and bottom padding from container for timetable, and removed gaps between timetable columns.

![image](https://github.com/user-attachments/assets/f1b56994-03c9-4be9-a4ea-c01b5daaec9f)
